### PR TITLE
set timezone in dockerfile

### DIFF
--- a/src/test/integration/Dockerfile
+++ b/src/test/integration/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3
 
+ARG timezone="America/Los_Angeles"
+
+# Set the timezone
+RUN echo $timezone | tee /etc/timezone && \
+    ln -fs /usr/share/zoneinfo/${timezone} /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
This sets the default timezone to america/los_angeles

Borrowed from https://github.com/osu-mist/ansible-roles/blob/67d7ebc708b12adc81a18e69d0f3a7299c3249bd/roles/api-environment/files/dropwizard-api/Dockerfile#L3-L8